### PR TITLE
add .oncall <msg> to notify the oncall person

### DIFF
--- a/scripts/pagerv2_commands.coffee
+++ b/scripts/pagerv2_commands.coffee
@@ -39,7 +39,7 @@
 #   hubot pd [who is] oncall        - tells who is currently on call
 #   hubot pd [who is] next [oncall] - tells who is next on call
 #
-#   hubot pd [tell to|cc] oncall <message> - cc oncall and send <message> to alerting channel
+#   hubot pd [tell to |cc ] oncall <message> - cc oncall and send <message> to alerting channel
 #
 #   hubot pd maintenances           - lists currently active maintenances
 #   hubot pd stfu|down [for] <duration> [because <reason>] - creates a maintenance
@@ -106,8 +106,8 @@ module.exports = (robot) ->
       res.send e
     res.finish()
 
-#   hubot pd [tell to|cc] oncall <message> - cc oncall and send <message> to alerting channel
-  robot.respond /(?:pd )?(?:tell to|cc)?on ?call\s(.+)/, 'pd_msg_oncall', (res) ->
+#   hubot pd [tell to |cc ] oncall <message> - cc oncall and send <message> to alerting channel
+  robot.respond /(?:pd )?(?:tell to |cc )?on ?call\s(.+)/, 'pd_msg_oncall', (res) ->
     [ _, msg ] = res.match
     alertchan = process.env.PAGERV2_ANNOUNCE_ROOM
     pagerv2.getOncall()

--- a/scripts/pagerv2_commands.coffee
+++ b/scripts/pagerv2_commands.coffee
@@ -39,6 +39,8 @@
 #   hubot pd [who is] oncall        - tells who is currently on call
 #   hubot pd [who is] next [oncall] - tells who is next on call
 #
+#   hubot pd [tell to|cc] oncall <message> - cc oncall and send <message> to alerting channel
+#
 #   hubot pd maintenances           - lists currently active maintenances
 #   hubot pd stfu|down [for] <duration> [because <reason>] - creates a maintenance
 #   hubot pd up|end|back <maintenance> - ends <maintenance>
@@ -100,6 +102,24 @@ module.exports = (robot) ->
     .bind(who)
     .then (data) ->
       res.send "Ok now I know #{who} is #{data}."
+    .catch (e) ->
+      res.send e
+    res.finish()
+
+#   hubot pd [tell to|cc] oncall <message> - cc oncall and send <message> to alerting channel
+  robot.respond /(?:pd )?(?:tell to|cc)?on ?call\s(.+)/, 'pd_msg_oncall', (res) ->
+    [ _, msg ] = res.match
+    alertchan = process.env.PAGERV2_ANNOUNCE_ROOM
+    pagerv2.getOncall()
+    .then (data) ->
+      if res.envelope.room is res.envelope.user.room
+        res.send "I'll notify #{data.user.summary}"
+      else
+        res.send "cc #{data.user.summary}"
+      if alertchan isnt res.envelope.room
+        origin = if res.envelope.room then "on #{res.envelope.room}" else ''
+        robot.messageRoom alertchan,
+            "#{data.user.summary} : #{msg} - #{res.envelope.user.name} #{origin}"
     .catch (e) ->
       res.send e
     res.finish()

--- a/test/pagerv2_commands_test.coffee
+++ b/test/pagerv2_commands_test.coffee
@@ -253,7 +253,47 @@ describe 'pagerv2_commands', ->
         it 'returns information from pager', ->
           expect(hubotResponse())
           .to.eql 'Ok now I know toto is PXPGF42.'
+  # ------------------------------------------------------------------------------------------------
+  describe '".pd oncall <msg>"', ->
+    context 'when something goes wrong,', ->
+      beforeEach ->
+        room.robot.brain.data.pagerv2 = { users: { } }
+        nock('https://api.pagerduty.com')
+        .get('/oncalls')
+        .query({
+          time_zone: 'UTC',
+          schedule_ids: [ 42 ],
+          earliest: true
+        })
+        .reply 503, { error: { code: 503, message: "it's all broken!" } }
+      afterEach ->
+        room.robot.brain.data.pagerv2 = { }
+        nock.cleanAll()
 
+      say 'pd oncall', ->
+        it 'returns the error message', ->
+          expect(hubotResponse())
+          .to.eql "503 it's all broken!"
+
+    context 'when everything goes right,', ->
+      beforeEach ->
+        room.robot.brain.data.pagerv2 = { users: { } }
+        nock('https://api.pagerduty.com')
+        .get('/oncalls')
+        .query({
+          time_zone: 'UTC',
+          schedule_ids: [ 42 ],
+          earliest: true
+        })
+        .reply 200, require('./fixtures/oncall_list-ok.json')
+      afterEach ->
+        room.robot.brain.data.pagerv2 = { }
+        nock.cleanAll()
+
+      say 'pd oncall doing stuff', ->
+        it 'returns name of who is on call', ->
+          expect(hubotResponse())
+          .to.eql 'I\'ll notify Tim Wright'
   # ------------------------------------------------------------------------------------------------
   describe '".pd oncall"', ->
     context 'when something goes wrong,', ->

--- a/test/pagerv2_commands_test.coffee
+++ b/test/pagerv2_commands_test.coffee
@@ -270,7 +270,7 @@ describe 'pagerv2_commands', ->
         room.robot.brain.data.pagerv2 = { }
         nock.cleanAll()
 
-      say 'pd oncall', ->
+      say 'pd oncall doing stuff', ->
         it 'returns the error message', ->
           expect(hubotResponse())
           .to.eql "503 it's all broken!"


### PR DESCRIPTION
behaviour of .oncall <msg> 
in the same chan 
    answer : cc <oncallperson>
in query
    answer : I'll notify <oncallperson> 
both case : 
    hilight <oncallperson> on PAGERV2_ANNOUNCE_ROOM and send <msg>

note : there is a fail safe in case the origin chan is the same as announce room.